### PR TITLE
Callable import change

### DIFF
--- a/src/mtuprobe/probe.py
+++ b/src/mtuprobe/probe.py
@@ -1,4 +1,7 @@
-from collections import Callable
+try:
+    from collections.abc import Callable  # Python >= 3.7
+except ImportError:
+    from collections import Callable 
 
 
 def bisect(n, mapper, tester):


### PR DESCRIPTION
Hi,

Since Python 3.7, Callable isn't in collections anymore, bit in collections.abc